### PR TITLE
EditPage's "task is done" TextSwitch works the wrong way

### DIFF
--- a/qml/pages/EditPage.qml
+++ b/qml/pages/EditPage.qml
@@ -124,7 +124,7 @@ Dialog {
             TextSwitch {
                 id: taskStatus
                 text: qsTr("task is done")
-                checked: taskListWindow.statusOpen(editTaskPage.taskstatus)
+                checked: !taskListWindow.statusOpen(editTaskPage.taskstatus)
             }
 
             ComboBox {


### PR DESCRIPTION
On _EditPage_ there is _TextSwitch_ with text "task is done" but it is selected when the task is open. Now it works as I think it should. 
