### PR TITLE
Closed tasks appearance

### DIFF
--- a/qml/harbour-tasklist.qml
+++ b/qml/harbour-tasklist.qml
@@ -68,11 +68,6 @@ ApplicationWindow {
         //% "Tags"
         qsTrId("tags-label")
     ]
-    // set default priorities
-    property int minimumPriority: 1
-    property int defaultPriority: 3
-    property int maximumPriority: 5
-
     property bool coverActionMultiple: listOfLists.length > 1
     property bool coverActionSingle: !coverActionMultiple
 

--- a/qml/harbour-tasklist.qml
+++ b/qml/harbour-tasklist.qml
@@ -88,7 +88,12 @@ ApplicationWindow {
     property int backFocusAddTask
     property bool smartListVisibility
     property int recentlyAddedOffset
-    property bool doneTasksStrikedThrough
+    /* How closed task appears:
+     * - 0: don't show
+     * - 1: not selected text switch
+     * - 2: striked through text switch
+     */
+    property int closedTaskAppearance
 
     initialPage: DB.schemaIsUpToDate() ? initialTaskPage : migrateConfirmation
     cover: Component { CoverPage {} }
@@ -404,7 +409,10 @@ ApplicationWindow {
         backFocusAddTask = DB.getSettingAsNumber("backFocusAddTask")
         smartListVisibility = DB.getSettingAsNumber("smartListVisibility") === 1
         recentlyAddedOffset = DB.getSettingAsNumber("recentlyAddedOffset")
-        doneTasksStrikedThrough = DB.getSettingAsNumber("doneTasksStrikedThrough") === 1
+        // default appearance: not shown
+        closedTaskAppearance = DB.getSettingAsNumber("closedTaskAppearance", 0)
+        // check range
+        closedTaskAppearance = Math.min(Math.max(closedTaskAppearance, 0), 2)
     }
 
     Notification {

--- a/qml/harbour-tasklist.qml
+++ b/qml/harbour-tasklist.qml
@@ -32,8 +32,8 @@ ApplicationWindow {
     property int listid
     // save defaultlist in a global context
     property int defaultlist
-    // helper variable to reload list on list name or task name changes
-    property bool listchanged: false
+    // helper variable to indicate the need to update list model data in TaskPage
+    property bool needListModelReload: false
     // helper varable for adding directly through coveraction
     property bool coverAddTask: false
     // helper varable to lock task Page Orientation
@@ -96,6 +96,10 @@ ApplicationWindow {
     Component {
         id: initialTaskPage
         TaskPage { }
+    }
+
+    onClosedTaskAppearanceChanged: {
+        needListModelReload = true
     }
 
     Component {

--- a/qml/localdb.js
+++ b/qml/localdb.js
@@ -200,7 +200,7 @@ function initializeDB() {
                 "backFocusAddTask": 1,
                 "smartListVisibility": 1,
                 "recentlyAddedOffset": 3,
-                "doneTasksStrikedThrough": 0
+                "closedTaskAppearance": 0
             };
             for (var settingKey in defaultSettings) {
                 var res = tx.executeSql("SELECT count(Setting) as cSetting FROM settings WHERE Setting = ?;", settingKey);
@@ -756,11 +756,17 @@ function getSetting(setting) {
     return value;
 }
 
-function getSettingAsNumber(setting) {
+/*
+ *  If no value is found, then default_val will be
+ * saved (if it's not empty) and returned
+ */
+function getSettingAsNumber(setting, defaultValue) {
     var value = getSetting(setting);
     if (typeof value !== "undefined")
-        value = Number(value);
-    return value;
+        return Number(value);
+    if (typeof defaultValue !== "undefined")
+        updateSetting(setting, defaultValue);
+    return defaultValue;
 }
 
 var DROPBOX_FIELDS = {

--- a/qml/pages/CoverPage.qml
+++ b/qml/pages/CoverPage.qml
@@ -85,7 +85,7 @@ CoverBackground {
 
             if (taskListWindow.smartListType !== -1) {
                 taskListWindow.smartListType = -1
-                taskListWindow.listchanged = true
+                taskListWindow.needListModelReload = true
             }
 
             // reload tasklist if navigateBack was used from list page

--- a/qml/pages/SettingsPage.qml
+++ b/qml/pages/SettingsPage.qml
@@ -110,7 +110,7 @@ Dialog {
         DB.updateSetting("startPage", startPage.currentIndex)
         DB.updateSetting("smartListVisibility", smartListVisibility.checked === true ? 1 : 0)
         DB.updateSetting("recentlyAddedOffset", recentlyAddedOffset.currentIndex)
-        DB.updateSetting("closedTaskApearance", closedTasksAppearance.currentIndex)
+        var ret = DB.updateSetting("closedTaskAppearance", closedTasksAppearance.currentIndex)
 
         // push new settings to runtime variables
         taskListWindow.coverListSelection = coverListSelection.currentIndex

--- a/qml/pages/SettingsPage.qml
+++ b/qml/pages/SettingsPage.qml
@@ -78,7 +78,6 @@ Dialog {
         languages.append({ lang: "tr_TR",           name: "Türkçe"})
         languages.append({ lang: "zh_CN",           name: "中文"})
 
-
         language = taskListWindow.getLanguage()
         var found = false
         for (var i = 0; i < languages.count; ++i) {
@@ -110,7 +109,7 @@ Dialog {
         DB.updateSetting("startPage", startPage.currentIndex)
         DB.updateSetting("smartListVisibility", smartListVisibility.checked === true ? 1 : 0)
         DB.updateSetting("recentlyAddedOffset", recentlyAddedOffset.currentIndex)
-        var ret = DB.updateSetting("closedTaskAppearance", closedTasksAppearance.currentIndex)
+        DB.updateSetting("closedTaskAppearance", closedTasksAppearance.currentIndex)
 
         // push new settings to runtime variables
         taskListWindow.coverListSelection = coverListSelection.currentIndex

--- a/qml/pages/SettingsPage.qml
+++ b/qml/pages/SettingsPage.qml
@@ -110,8 +110,7 @@ Dialog {
         DB.updateSetting("startPage", startPage.currentIndex)
         DB.updateSetting("smartListVisibility", smartListVisibility.checked === true ? 1 : 0)
         DB.updateSetting("recentlyAddedOffset", recentlyAddedOffset.currentIndex)
-        DB.updateSetting("doneTasksStrikedThrough", doneTasksStrikedThrough.checked === true ? 1 : 0)
-
+        DB.updateSetting("closedTaskApearance", closedTasksAppearance.currentIndex)
 
         // push new settings to runtime variables
         taskListWindow.coverListSelection = coverListSelection.currentIndex
@@ -123,7 +122,7 @@ Dialog {
         taskListWindow.remorseOnMultiAdd = remorseOnMultiAdd.value
         taskListWindow.smartListVisibility = smartListVisibility.checked === true ? 1 : 0
         taskListWindow.recentlyAddedOffset = recentlyAddedOffset.currentIndex
-        taskListWindow.doneTasksStrikedThrough = doneTasksStrikedThrough.checked === true ? 1 : 0
+        taskListWindow.closedTaskAppearance = closedTasksAppearance.currentIndex
 
         var langId = languageBox.currentIndex
         if (0 <= langId && langId < languages.count) {
@@ -276,13 +275,19 @@ Dialog {
             }
 
 
-            TextSwitch {
-                id: doneTasksStrikedThrough
+            ComboBox {
+                id: closedTasksAppearance
                 width: parent.width
-                //: user option to strike through done tasks for better task overview
-                //% "strike through done tasks"
-                text: qsTrId("strike-through-label")
-                checked: taskListWindow.doneTasksStrikedThrough
+                //: user option to select closed tasks appearance
+                //% "Closed tasks"
+                label: qsTrId("closed-task") + ":"
+                currentIndex: taskListWindow.closedTaskAppearance
+
+                menu: ContextMenu {
+                    MenuItem { text: qsTrId("hide") }
+                    MenuItem { text: qsTrId("unselect") }
+                    MenuItem { text: qsTrId("strike through") }
+                }
             }
 
             SectionHeader {

--- a/qml/pages/TaskListItem.qml
+++ b/qml/pages/TaskListItem.qml
@@ -157,7 +157,7 @@ MouseArea {
             right: prio.left
         }
         wrapMode: Text.NoWrap
-        font.strikeout: taskListWindow.doneTasksStrikedThrough === true ? !taskListWindow.statusOpen(checked) : false
+        font.strikeout: taskListWindow.closedTaskAppearance === 2 ? !taskListWindow.statusOpen(checked) : false
         color: highlighted ? Theme.highlightColor : (checked ? Theme.primaryColor : Theme.secondaryColor)
         truncationMode: TruncationMode.Elide
     }

--- a/qml/pages/TaskPage.qml
+++ b/qml/pages/TaskPage.qml
@@ -121,7 +121,7 @@ Page {
                 doneTaskCheck = true
         }
 
-        // final decision to enable or diable the menu item
+        // final decision to enable or disable the menu item
         doneTasksAvailable = doneTaskCheck
     }
 
@@ -215,16 +215,15 @@ Page {
         case PageStatus.Activating:
             if (taskListWindow.justStarted === true) {
                 taskListWindow.initializeApplication()
-
-                taskListWindow.listchanged = true
+                taskListWindow.needListModelReload = true
             }
 
             taskListWindow.fillListOfLists()
 
             // reload tasklist if task has been edited or current list is renamed
-            if (taskListWindow.listchanged === true) {
+            if (taskListWindow.needListModelReload) {
                 reloadTaskList()
-                taskListWindow.listchanged = false
+                taskListWindow.needListModelReload = false
             }
 
             break
@@ -296,7 +295,7 @@ Page {
             Row {
                 width: parent.width - 2 * Theme.paddingLarge
                 spacing: Theme.paddingLarge
-                visible: smartListType === -1 ? true : false
+                visible: smartListType === -1
 
                 TextField {
                     id: taskAdd
@@ -309,11 +308,9 @@ Page {
                     label: qsTrId("new-task-confirmation-description")
                     // enable enter key if minimum task length has been reached
                     EnterKey.enabled: text.length > 0
-                    // set allowed chars and task length
-                    //validator: RegExpValidator { regExp: /^.{,60}$/ }
 
                     function addTask(newTask) {
-                        var taskNew = newTask !== undefined ? newTask : taskAdd.text
+                        var taskNew = (typeof newTask !== 'undefined') ? newTask : taskAdd.text
                         if (taskNew.length > 0) {
                             // add task to db and tasklist
                             var result = DB.writeTask(listid, taskNew, 1, 0, 0, DB.PRIORITY_DEFAULT, "")
@@ -349,7 +346,7 @@ Page {
                             timerAddTask.start()
                     }
 
-                    visible: smartListType === -1 ? true : false
+                    visible: smartListType === -1
                     EnterKey.onClicked: addTask()
 
                     onTextChanged: {

--- a/qml/pages/TaskPage.qml
+++ b/qml/pages/TaskPage.qml
@@ -102,7 +102,11 @@ Page {
             DB.readSmartListTasks(taskListWindow.smartListType, appendTask)
         } else {
             listname = DB.getListName(listid)
-            DB.readTasks(listid, appendTask)
+            var statusFilter = undefined
+            // check if we need to filter out closed tasks
+            if (taskListWindow.closedTaskAppearance === 0)
+                statusFilter = "1"
+            DB.readTasks(listid, appendTask, statusFilter)
         }
 
         // disable pulldown menus if no done tasks available
@@ -558,7 +562,7 @@ Page {
                     // insert Item to correct position
                     if (status && !recurring) {
                         taskListModel.insert(0, newTask)
-                    } else {
+                    } else if (taskListWindow.closedTaskAppearance > 0) {
                         var i;
                         for (i = 0; i < taskListModel.count; i++)
                             if (!taskListModel.get(i).taskstatus)


### PR DESCRIPTION
PR introduces an option to hide closed tasks besides the current options to (un)select switch and strike it through.

If one wants to keep tasks (e.g. for history), but doesn't want to see them around, then I figured this option could be helpful.

Please review.